### PR TITLE
Handle budget_total in trip requests

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Literal, Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, AliasChoices, ConfigDict
 
 # ------- Request models -------
 class TripPrefs(BaseModel):
@@ -19,10 +19,12 @@ class Dates(BaseModel):
     end: str
 
 class TripRequest(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
     origin: str
     destinations: List[str]
     dates: Dates
-    budget: float
+    budget_total: float = Field(..., validation_alias=AliasChoices("budget_total", "budget"))
     currency: str = "USD"
     party: Party = Party()
     prefs: TripPrefs = TripPrefs()

--- a/tests/test_trip_request_schema.py
+++ b/tests/test_trip_request_schema.py
@@ -1,0 +1,43 @@
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from app.schemas import TripRequest
+from app.orchestrator import plan_trip
+
+SAMPLE_PAYLOAD = {
+    "origin": "San Francisco",
+    "purpose": "family vacation",
+    "budget_total": 4500,
+    "currency": "USD",
+    "dates": {"start": "2025-07-10", "end": "2025-07-20"},
+    "party": {"adults": 2, "children": 1, "seniors": 0},
+    "constraints": {"diet": ["vegetarian"], "max_flight_hours": 12},
+    "interests": ["culture", "food", "museums", "kid-friendly"],
+    "destinations": ["Paris", "Amsterdam", "Berlin"],
+}
+
+
+def test_trip_request_budget_total_round_trip():
+    trip_req = TripRequest.model_validate(SAMPLE_PAYLOAD)
+
+    assert trip_req.budget_total == SAMPLE_PAYLOAD["budget_total"]
+
+    dumped = trip_req.model_dump()
+    assert dumped["budget_total"] == SAMPLE_PAYLOAD["budget_total"]
+
+    response = plan_trip(trip_req)
+    echoed = response.query_echo
+    assert echoed.budget_total == SAMPLE_PAYLOAD["budget_total"]
+
+    echoed_dump = response.model_dump(mode="json")
+    assert echoed_dump["query_echo"]["budget_total"] == SAMPLE_PAYLOAD["budget_total"]
+
+
+def test_trip_request_accepts_legacy_budget_field():
+    legacy_payload = {**SAMPLE_PAYLOAD}
+    legacy_payload.pop("budget_total")
+    legacy_payload["budget"] = 3200
+
+    trip_req = TripRequest.model_validate(legacy_payload)
+    assert trip_req.budget_total == 3200


### PR DESCRIPTION
## Summary
- allow `TripRequest` to accept `budget_total` alongside the legacy `budget` key and ignore extra payload fields
- parse incoming payloads with the schema before running the deterministic planner and return baseline data when LLM calls fail
- add tests verifying the schema preserves the budget field and accepts legacy payloads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca312a1ac48331ab76b3e454f1dafd