### PR TITLE
Add Tavily-backed web search with policy filtering

### DIFF
--- a/app/tools/websearch.py
+++ b/app/tools/websearch.py
@@ -1,7 +1,11 @@
 from dataclasses import dataclass
-from typing import List, Optional, Sequence, Dict
+from typing import List, Optional, Sequence, Dict, Iterable
+from urllib.parse import urlparse
+import os
 import re
+
 import httpx
+
 from .html_to_text import html_to_text
 
 @dataclass
@@ -31,12 +35,43 @@ class WebSearcher:
     """
     Pluggable search+fetch. Replace `search()` with your provider (Bing/SerpAPI/Tavily).
     """
-    def __init__(self, policy: SourcePolicy):
+    SEARCH_ENDPOINT = "https://api.tavily.com/search"
+
+    def __init__(self, policy: SourcePolicy, *, api_key: Optional[str] = None):
         self.policy = policy
+        self.api_key = api_key or os.getenv("TAVILY_API_KEY")
 
     async def search(self, query: str) -> List[Dict]:
-        # TODO: wire up your preferred search API and return [{'url':..., 'title':...}, ...]
-        return []
+        """Run a Tavily search and return filtered results.
+
+        The returned payload only contains ``url`` + ``title`` pairs because the
+        orchestrator performs its own fetching step for snippets.  Results are
+        pre-filtered according to the configured ``SourcePolicy`` so callers do
+        not have to re-apply allow/deny logic.
+        """
+        if not self.api_key:
+            raise RuntimeError("TAVILY_API_KEY environment variable not configured")
+
+        payload = {
+            "api_key": self.api_key,
+            "query": query,
+            "search_depth": "basic",
+            "max_results": self.policy.max_results * 2,
+            "include_answer": False,
+            "include_images": False,
+        }
+        if self.policy.allow_domains:
+            payload["include_domains"] = list(self.policy.allow_domains)
+        if self.policy.deny_domains:
+            payload["exclude_domains"] = list(self.policy.deny_domains)
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(self.SEARCH_ENDPOINT, json=payload)
+            response.raise_for_status()
+            data = response.json()
+
+        raw_results: Iterable[Dict] = data.get("results", [])
+        return self._apply_policy(raw_results)
 
     async def fetch(self, url: str, timeout: float = 10.0) -> Optional[WebDoc]:
         if not self.policy.allowed(url):
@@ -57,3 +92,41 @@ class WebSearcher:
         if m:
             return re.sub(r"\s+", " ", m.group(1)).strip()
         return None
+
+    def _apply_policy(self, results: Iterable[Dict]) -> List[Dict]:
+        filtered: List[Dict] = []
+        seen_urls: set[str] = set()
+        per_domain: Dict[str, int] = {}
+
+        for result in results:
+            url = result.get("url") or result.get("href")
+            if not url:
+                continue
+            if url in seen_urls:
+                continue
+            if not self.policy.allowed(url):
+                continue
+
+            domain = self._domain_for(url)
+            if not domain:
+                continue
+            if per_domain.get(domain, 0) >= self.policy.max_per_domain:
+                continue
+
+            title = result.get("title") or ""
+            filtered.append({"url": url, "title": title})
+            seen_urls.add(url)
+            per_domain[domain] = per_domain.get(domain, 0) + 1
+
+            if len(filtered) >= self.policy.max_results:
+                break
+
+        return filtered
+
+    @staticmethod
+    def _domain_for(url: str) -> str:
+        try:
+            parsed = urlparse(url)
+        except ValueError:
+            return ""
+        return (parsed.netloc or "").lower()

--- a/tests/test_websearch.py
+++ b/tests/test_websearch.py
@@ -1,0 +1,128 @@
+from typing import List
+
+import httpx
+import pytest
+
+from app.tools.websearch import WebSearcher, SourcePolicy, WebDoc
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class DummyAsyncClient:
+    def __init__(self, response_payload, *args, **kwargs):
+        self.response_payload = response_payload
+        self.requests: List[tuple] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+    async def post(self, url, json):
+        self.requests.append((url, json))
+        return DummyResponse(self.response_payload)
+
+
+@pytest.mark.asyncio
+async def test_websearch_search_applies_source_policy(monkeypatch):
+    payload = {
+        "results": [
+            {"url": "https://allowed.com/a", "title": "A"},
+            {"url": "https://allowed.com/a", "title": "A duplicate"},
+            {"url": "https://denied.com/x", "title": "Denied"},
+            {"url": "https://other.com/1", "title": "Other 1"},
+            {"url": "https://other.com/2", "title": "Other 2"},
+            {"url": "https://other.com/3", "title": "Other 3"},
+        ]
+    }
+
+    monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **kw: DummyAsyncClient(payload, *a, **kw))
+
+    policy = SourcePolicy(deny_domains=[r"denied\.com"], max_results=4, max_per_domain=1)
+    searcher = WebSearcher(policy)
+
+    results = await searcher.search("family travel ideas")
+
+    assert len(results) == 2  # allowed.com and first other.com entry
+    assert {r["url"] for r in results} == {"https://allowed.com/a", "https://other.com/1"}
+    assert all(r["title"] for r in results)
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_dedupes_and_fetches_unique_results(monkeypatch):
+    from app import orchestrator
+
+    collected_snippets = {}
+
+    def fake_call_llm(payload, snippets):
+        collected_snippets["value"] = list(snippets)
+        return {"llm": "ok"}
+
+    monkeypatch.setattr(orchestrator, "call_llm", fake_call_llm)
+
+    instances = []
+
+    class FakeSearcher:
+        def __init__(self, policy):
+            self.policy = policy
+            self.search_calls: List[str] = []
+            self.fetch_calls: List[str] = []
+            instances.append(self)
+
+        async def search(self, query: str):
+            self.search_calls.append(query)
+            return [
+                {"url": "https://allowed.com/a", "title": "A"},
+                {"url": "https://allowed.com/a", "title": "A duplicate"},
+                {"url": "https://denied.com/z", "title": "Denied"},
+                {"url": "https://other.com/1", "title": "Other 1"},
+                {"url": "https://other.com/2", "title": "Other 2"},
+            ]
+
+        async def fetch(self, url: str):
+            self.fetch_calls.append(url)
+            return WebDoc(url=url, title=f"Title for {url}", text="Snippet text")
+
+    monkeypatch.setattr(orchestrator, "WebSearcher", FakeSearcher)
+
+    payload = {
+        "origin": "Paris",
+        "destinations": ["Rome", "Milan"],
+        "dates": {"start": "2025-01-01", "end": "2025-01-05"},
+        "budget_total": 2000.0,
+        "currency": "EUR",
+        "party": {"adults": 2},
+        "prefs": {"objective": "balanced"},
+    }
+
+    data = await orchestrator.orchestrate_llm_trip(
+        payload,
+        allow_domains=[r"allowed\.com", r"other\.com"],
+        deny_domains=[r"denied\.com"],
+    )
+
+    # Only unique allowed URLs should be fetched.
+    assert instances, "WebSearcher should have been instantiated"
+    fetch_calls = instances[0].fetch_calls
+    assert fetch_calls == [
+        "https://allowed.com/a",
+        "https://other.com/1",
+        "https://other.com/2",
+    ]
+
+    snippets = data.get("snippets")
+    assert snippets is not None
+    assert len(snippets) == 3
+    assert {s["url"] for s in snippets} == set(fetch_calls)
+    assert collected_snippets["value"] == snippets


### PR DESCRIPTION
## Summary
- implement a Tavily-backed `WebSearcher.search` that filters results against `SourcePolicy`
- add policy-aware helper utilities for deduping and domain limiting prior to orchestrator use
- introduce async pytest coverage for search filtering and orchestrator deduplication behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ca3277f8448331bb90be4b877a7e8e