### PR TITLE
Preserve raw payload extras in orchestrator foundation context

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -205,8 +205,8 @@ async def orchestrate_llm_trip(payload: Dict[str, Any],
                                allow_domains: List[str] | None = None,
                                deny_domains: List[str] | None = None) -> Dict[str, Any]:
     """Build queries, optionally web-search + fetch snippets, call LLM, return dict."""
+    foundation = extract_foundation(payload)
     trip_req = TripRequest.model_validate(payload)
-    foundation = extract_foundation(trip_req)
 
     # Build queries from payload
     queries: List[str] = []


### PR DESCRIPTION
## Summary
- call `extract_foundation` with the raw payload before schema validation so supplemental fields remain available to downstream agents
- extend the orchestrator tests to ensure interests and constraints survive in the agent context foundation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca3daf39a0833187814024eb853bd0