### PR TITLE
Improve trip orchestration with budget-aware logging and resilience

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "trip-planner"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.116.1",
     "httpx>=0.28.1",
@@ -13,5 +13,15 @@ dependencies = [
     "python-dotenv>=1.1.1",
     "pyyaml>=6.0.2",
     "redis>=6.4.0",
+    "requests>=2.32.3",
     "uvicorn[standard]>=0.35.0",
+    "pytest>=8.4.1",
+    "pytest-asyncio>=0.23.8",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.4.1",
+    "pytest-asyncio>=0.23.8",
+    "requests>=2.32.3",
 ]


### PR DESCRIPTION
## Summary
- add structured logging to the orchestrator and LLM wrapper so planning steps stream to the terminal
- rebalance bundle construction to stay near the requested budget, trim travel time, and surface date-shift suggestions for better value
- fall back to a stubbed LLM response when no OpenAI API key is configured and declare test dependencies in pyproject.toml

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca4a86239883318be6085c19e0101e