### PR TITLE
Improve web sourcing and LLM fallbacks

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -42,6 +42,30 @@ If unsure, mark facts as 'indicative' and do not invent citations.
 Return ONLY valid JSON.
 """
 
+CITY_BACKFILL_SYSTEM = """You are a cautious travel research assistant.
+When web scraping fails, provide conservative fallback guidance.
+Respond ONLY in JSON with the schema:
+  {"cities": {"CITY": {"highlights": [], "experiences": [], "dining": [], "notes": []}}}
+- highlights: 2-4 iconic, family-friendly attractions per city.
+- experiences: activities or pacing tips aligned with the party profile.
+- dining: vegetarian-friendly or flexible dining ideas (0-3 entries).
+- notes: caveats when reliable data is unavailable.
+Do not fabricate pricing or availability.
+Leave arrays empty when uncertain.
+"""
+
+CITY_BACKFILL_TEMPLATE = """We are missing verified web intel for these cities: {cities}.
+Trip context summary:
+- origin: {origin}
+- dates: {dates}
+- party: {party}
+- interests: {interests}
+- dietary: {diet}
+
+Provide concise bullet-style strings (<=120 characters each).
+If information is generic knowledge, mark it as indicative (e.g., "Indicative: ...").
+"""
+
 USER_TEMPLATE = """User profile:
 origin: {origin}
 purpose: {purpose}
@@ -116,3 +140,110 @@ def call_llm(payload: Dict[str, Any], snippets: List[Dict[str, str]], model: str
     except Exception:
         logger.warning("LLM response was not valid JSON; returning raw text")
         return {"error": "Invalid JSON from model", "raw": raw}
+
+
+def _summarise_party(party: Dict[str, Any] | None) -> str:
+    if not isinstance(party, dict):
+        return "unspecified"
+    adults = party.get("adults")
+    children = party.get("children")
+    seniors = party.get("seniors")
+    bits: List[str] = []
+    if adults:
+        bits.append(f"{adults} adults")
+    if children:
+        bits.append(f"{children} children")
+    if seniors:
+        bits.append(f"{seniors} seniors")
+    return ", ".join(bits) if bits else "unspecified"
+
+
+def _summarise_dates(dates: Dict[str, Any] | None) -> str:
+    if not isinstance(dates, dict):
+        return "unspecified"
+    start = dates.get("start") or dates.get("begin")
+    end = dates.get("end") or dates.get("finish")
+    if start and end:
+        return f"{start} to {end}"
+    return start or end or "unspecified"
+
+
+def llm_backfill_city_details(
+    cities: List[str],
+    foundation: Dict[str, Any],
+    *,
+    model: str = "gpt-4o-mini",
+) -> Dict[str, Dict[str, List[str]]]:
+    """Use the hosted LLM to backfill destination intel when web data is missing."""
+
+    clean_cities = [c for c in (cities or []) if c]
+    if not clean_cities:
+        return {}
+
+    if _client is None:  # pragma: no cover - exercised via stub in tests
+        logger.info(
+            "Skipping LLM backfill for cities %s (missing client or API key)",
+            ", ".join(clean_cities),
+        )
+        return {}
+
+    origin = foundation.get("origin")
+    dates = foundation.get("dates")
+    party = foundation.get("party")
+    interests = foundation.get("interests") or []
+    constraints = foundation.get("constraints") or {}
+    diet = constraints.get("diet") or foundation.get("diet") or []
+
+    user_prompt = CITY_BACKFILL_TEMPLATE.format(
+        cities=", ".join(clean_cities),
+        origin=origin or "unspecified",
+        dates=_summarise_dates(dates),
+        party=_summarise_party(party),
+        interests=", ".join(interests) if interests else "none stated",
+        diet=", ".join(diet) if diet else "none stated",
+    )
+
+    logger.info(
+        "Invoking LLM model %s for destination backfill (%d cities)",
+        model,
+        len(clean_cities),
+    )
+
+    resp = _client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": CITY_BACKFILL_SYSTEM},
+            {"role": "user", "content": user_prompt},
+        ],
+        temperature=0.2,
+        response_format={"type": "json_object"},
+    )
+
+    raw = resp.choices[0].message.content
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        logger.warning("LLM city backfill returned non-JSON payload; ignoring", exc_info=True)
+        return {}
+
+    city_block = payload.get("cities")
+    if not isinstance(city_block, dict):
+        return {}
+
+    normalised: Dict[str, Dict[str, List[str]]] = {}
+    for city in clean_cities:
+        data = city_block.get(city) or city_block.get(city.lower()) or {}
+        if not isinstance(data, dict):
+            data = {}
+        highlights = [item for item in data.get("highlights", []) if isinstance(item, str)]
+        experiences = [item for item in data.get("experiences", []) if isinstance(item, str)]
+        dining = [item for item in data.get("dining", []) if isinstance(item, str)]
+        notes = [item for item in data.get("notes", []) if isinstance(item, str)]
+        normalised[city] = {
+            "highlights": highlights[:4],
+            "experiences": experiences[:5],
+            "dining": dining[:3],
+            "notes": notes[:3],
+        }
+
+    return normalised

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -57,6 +57,8 @@ class AgentContext(BaseModel):
     notes: List[str] = Field(default_factory=list)
     sources: List[Dict[str, str]] = Field(default_factory=list)
     snippets: List[Dict[str, str]] = Field(default_factory=list)
+    costs: Dict[str, object] = Field(default_factory=dict)
+    llm_sources: List[Dict[str, object]] = Field(default_factory=list)
 
 class PlanBundle(BaseModel):
     label: Literal["balanced","cheapest","comfort","family_friendly"]


### PR DESCRIPTION
## Summary
- add structured logging and fallback handling to web search fetches so summary text is saved when pages cannot be retrieved
- warn when destination heuristics kick in and use the LLM to backfill missing highlights, tracking the model as a source
- record baseline cost breakdowns inside the agent context and expose them alongside snippet and source metadata

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca51ce207483319527eb2cde80e944