### PR TITLE
Add booking links to plan bundles

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -42,6 +42,30 @@ If unsure, mark facts as 'indicative' and do not invent citations.
 Return ONLY valid JSON.
 """
 
+CITY_BACKFILL_SYSTEM = """You are a cautious travel research assistant.
+When web scraping fails, provide conservative fallback guidance.
+Respond ONLY in JSON with the schema:
+  {"cities": {"CITY": {"highlights": [], "experiences": [], "dining": [], "notes": []}}}
+- highlights: 2-4 iconic, family-friendly attractions per city.
+- experiences: activities or pacing tips aligned with the party profile.
+- dining: vegetarian-friendly or flexible dining ideas (0-3 entries).
+- notes: caveats when reliable data is unavailable.
+Do not fabricate pricing or availability.
+Leave arrays empty when uncertain.
+"""
+
+CITY_BACKFILL_TEMPLATE = """We are missing verified web intel for these cities: {cities}.
+Trip context summary:
+- origin: {origin}
+- dates: {dates}
+- party: {party}
+- interests: {interests}
+- dietary: {diet}
+
+Provide concise bullet-style strings (<=120 characters each).
+If information is generic knowledge, mark it as indicative (e.g., "Indicative: ...").
+"""
+
 USER_TEMPLATE = """User profile:
 origin: {origin}
 purpose: {purpose}
@@ -116,3 +140,110 @@ def call_llm(payload: Dict[str, Any], snippets: List[Dict[str, str]], model: str
     except Exception:
         logger.warning("LLM response was not valid JSON; returning raw text")
         return {"error": "Invalid JSON from model", "raw": raw}
+
+
+def _summarise_party(party: Dict[str, Any] | None) -> str:
+    if not isinstance(party, dict):
+        return "unspecified"
+    adults = party.get("adults")
+    children = party.get("children")
+    seniors = party.get("seniors")
+    bits: List[str] = []
+    if adults:
+        bits.append(f"{adults} adults")
+    if children:
+        bits.append(f"{children} children")
+    if seniors:
+        bits.append(f"{seniors} seniors")
+    return ", ".join(bits) if bits else "unspecified"
+
+
+def _summarise_dates(dates: Dict[str, Any] | None) -> str:
+    if not isinstance(dates, dict):
+        return "unspecified"
+    start = dates.get("start") or dates.get("begin")
+    end = dates.get("end") or dates.get("finish")
+    if start and end:
+        return f"{start} to {end}"
+    return start or end or "unspecified"
+
+
+def llm_backfill_city_details(
+    cities: List[str],
+    foundation: Dict[str, Any],
+    *,
+    model: str = "gpt-4o-mini",
+) -> Dict[str, Dict[str, List[str]]]:
+    """Use the hosted LLM to backfill destination intel when web data is missing."""
+
+    clean_cities = [c for c in (cities or []) if c]
+    if not clean_cities:
+        return {}
+
+    if _client is None:  # pragma: no cover - exercised via stub in tests
+        logger.info(
+            "Skipping LLM backfill for cities %s (missing client or API key)",
+            ", ".join(clean_cities),
+        )
+        return {}
+
+    origin = foundation.get("origin")
+    dates = foundation.get("dates")
+    party = foundation.get("party")
+    interests = foundation.get("interests") or []
+    constraints = foundation.get("constraints") or {}
+    diet = constraints.get("diet") or foundation.get("diet") or []
+
+    user_prompt = CITY_BACKFILL_TEMPLATE.format(
+        cities=", ".join(clean_cities),
+        origin=origin or "unspecified",
+        dates=_summarise_dates(dates),
+        party=_summarise_party(party),
+        interests=", ".join(interests) if interests else "none stated",
+        diet=", ".join(diet) if diet else "none stated",
+    )
+
+    logger.info(
+        "Invoking LLM model %s for destination backfill (%d cities)",
+        model,
+        len(clean_cities),
+    )
+
+    resp = _client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": CITY_BACKFILL_SYSTEM},
+            {"role": "user", "content": user_prompt},
+        ],
+        temperature=0.2,
+        response_format={"type": "json_object"},
+    )
+
+    raw = resp.choices[0].message.content
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        logger.warning("LLM city backfill returned non-JSON payload; ignoring", exc_info=True)
+        return {}
+
+    city_block = payload.get("cities")
+    if not isinstance(city_block, dict):
+        return {}
+
+    normalised: Dict[str, Dict[str, List[str]]] = {}
+    for city in clean_cities:
+        data = city_block.get(city) or city_block.get(city.lower()) or {}
+        if not isinstance(data, dict):
+            data = {}
+        highlights = [item for item in data.get("highlights", []) if isinstance(item, str)]
+        experiences = [item for item in data.get("experiences", []) if isinstance(item, str)]
+        dining = [item for item in data.get("dining", []) if isinstance(item, str)]
+        notes = [item for item in data.get("notes", []) if isinstance(item, str)]
+        normalised[city] = {
+            "highlights": highlights[:4],
+            "experiences": experiences[:5],
+            "dining": dining[:3],
+            "notes": notes[:3],
+        }
+
+    return normalised

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -36,6 +36,20 @@ class Stay(BaseModel):
     style: Literal["hotel", "boutique", "homestay", "apartment"] = "hotel"
     budget_per_night: float
 
+class BookingLink(BaseModel):
+    category: Literal[
+        "stay",
+        "flight",
+        "train",
+        "bus",
+        "local_pass",
+        "sightseeing",
+        "transport",
+    ]
+    label: str
+    url: str
+    details: Optional[str] = None
+
 class TravelLeg(BaseModel):
     mode: Literal["flight","train","bus","car","rideshare","metro","walk","ferry"]
     frm: str = Field(..., alias="from")
@@ -57,6 +71,8 @@ class AgentContext(BaseModel):
     notes: List[str] = Field(default_factory=list)
     sources: List[Dict[str, str]] = Field(default_factory=list)
     snippets: List[Dict[str, str]] = Field(default_factory=list)
+    costs: Dict[str, object] = Field(default_factory=dict)
+    llm_sources: List[Dict[str, object]] = Field(default_factory=list)
 
 class PlanBundle(BaseModel):
     label: Literal["balanced","cheapest","comfort","family_friendly"]
@@ -73,6 +89,7 @@ class PlanBundle(BaseModel):
     feasibility_notes: List[str] = Field(default_factory=list)
     transfer_buffers: Dict[str, float] = Field(default_factory=dict)
     scores: Dict[str, float] = Field(default_factory=dict)
+    booking_links: List[BookingLink] = Field(default_factory=list)
 
 class TripResponse(BaseModel):
     query_echo: TripRequest

--- a/tests/test_orchestrator_scoring.py
+++ b/tests/test_orchestrator_scoring.py
@@ -41,3 +41,13 @@ def test_max_flight_hours_penalises_comfort_plan():
     assert response.options[0].label != "comfort"
     comfort = next(opt for opt in response.options if opt.label == "comfort")
     assert comfort.scores["time"] < 0.8
+
+
+def test_plan_bundles_surface_booking_links():
+    response = plan_trip(_build_request("balanced"))
+    top_option = response.options[0]
+    assert top_option.booking_links, "expected booking links for the top bundle"
+    categories = {link.category for link in top_option.booking_links}
+    assert "stay" in categories
+    assert "local_pass" in categories
+    assert any(cat in categories for cat in {"train", "bus", "flight", "transport"})


### PR DESCRIPTION
## Summary
- extend plan bundles with a BookingLink schema so packages can carry booking URLs
- generate hotel, transport, city pass, and sightseeing links with prefilled dates and routes when planning trips
- cover the new booking link output with an orchestrator scoring test

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca51ce207483319527eb2cde80e944