### PR TITLE
Add standalone frontend inspired by conversational travel planners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,11 @@ dmypy.json
 *.tmp
 *.orig
 
+# ------------------------------
+# Node / front-end
+# ------------------------------
+node_modules/
+*.tsbuildinfo
+dist-ssr/
+*.vite.config.ts.timestamp
+

--- a/README.md
+++ b/README.md
@@ -88,5 +88,6 @@ All new features should include coverage in `tests/` where practical.
 - `app/llm.py` – wrapper around the OpenAI client with graceful fallbacks.
 - `app/agents/` – specialised heuristics for foundation, destination, and logistics insights.
 - `debug_orchestrator.py` – quick entry point for manual experiments.
+- `trip_planner_frontend/` – React + Vite workspace that mirrors conversational planners and surfaces booking links alongside orchestrator bundles. See its README for setup instructions.
 
 Happy trip planning!

--- a/app/llm.py
+++ b/app/llm.py
@@ -42,6 +42,30 @@ If unsure, mark facts as 'indicative' and do not invent citations.
 Return ONLY valid JSON.
 """
 
+CITY_BACKFILL_SYSTEM = """You are a cautious travel research assistant.
+When web scraping fails, provide conservative fallback guidance.
+Respond ONLY in JSON with the schema:
+  {"cities": {"CITY": {"highlights": [], "experiences": [], "dining": [], "notes": []}}}
+- highlights: 2-4 iconic, family-friendly attractions per city.
+- experiences: activities or pacing tips aligned with the party profile.
+- dining: vegetarian-friendly or flexible dining ideas (0-3 entries).
+- notes: caveats when reliable data is unavailable.
+Do not fabricate pricing or availability.
+Leave arrays empty when uncertain.
+"""
+
+CITY_BACKFILL_TEMPLATE = """We are missing verified web intel for these cities: {cities}.
+Trip context summary:
+- origin: {origin}
+- dates: {dates}
+- party: {party}
+- interests: {interests}
+- dietary: {diet}
+
+Provide concise bullet-style strings (<=120 characters each).
+If information is generic knowledge, mark it as indicative (e.g., "Indicative: ...").
+"""
+
 USER_TEMPLATE = """User profile:
 origin: {origin}
 purpose: {purpose}
@@ -116,3 +140,110 @@ def call_llm(payload: Dict[str, Any], snippets: List[Dict[str, str]], model: str
     except Exception:
         logger.warning("LLM response was not valid JSON; returning raw text")
         return {"error": "Invalid JSON from model", "raw": raw}
+
+
+def _summarise_party(party: Dict[str, Any] | None) -> str:
+    if not isinstance(party, dict):
+        return "unspecified"
+    adults = party.get("adults")
+    children = party.get("children")
+    seniors = party.get("seniors")
+    bits: List[str] = []
+    if adults:
+        bits.append(f"{adults} adults")
+    if children:
+        bits.append(f"{children} children")
+    if seniors:
+        bits.append(f"{seniors} seniors")
+    return ", ".join(bits) if bits else "unspecified"
+
+
+def _summarise_dates(dates: Dict[str, Any] | None) -> str:
+    if not isinstance(dates, dict):
+        return "unspecified"
+    start = dates.get("start") or dates.get("begin")
+    end = dates.get("end") or dates.get("finish")
+    if start and end:
+        return f"{start} to {end}"
+    return start or end or "unspecified"
+
+
+def llm_backfill_city_details(
+    cities: List[str],
+    foundation: Dict[str, Any],
+    *,
+    model: str = "gpt-4o-mini",
+) -> Dict[str, Dict[str, List[str]]]:
+    """Use the hosted LLM to backfill destination intel when web data is missing."""
+
+    clean_cities = [c for c in (cities or []) if c]
+    if not clean_cities:
+        return {}
+
+    if _client is None:  # pragma: no cover - exercised via stub in tests
+        logger.info(
+            "Skipping LLM backfill for cities %s (missing client or API key)",
+            ", ".join(clean_cities),
+        )
+        return {}
+
+    origin = foundation.get("origin")
+    dates = foundation.get("dates")
+    party = foundation.get("party")
+    interests = foundation.get("interests") or []
+    constraints = foundation.get("constraints") or {}
+    diet = constraints.get("diet") or foundation.get("diet") or []
+
+    user_prompt = CITY_BACKFILL_TEMPLATE.format(
+        cities=", ".join(clean_cities),
+        origin=origin or "unspecified",
+        dates=_summarise_dates(dates),
+        party=_summarise_party(party),
+        interests=", ".join(interests) if interests else "none stated",
+        diet=", ".join(diet) if diet else "none stated",
+    )
+
+    logger.info(
+        "Invoking LLM model %s for destination backfill (%d cities)",
+        model,
+        len(clean_cities),
+    )
+
+    resp = _client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": CITY_BACKFILL_SYSTEM},
+            {"role": "user", "content": user_prompt},
+        ],
+        temperature=0.2,
+        response_format={"type": "json_object"},
+    )
+
+    raw = resp.choices[0].message.content
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        logger.warning("LLM city backfill returned non-JSON payload; ignoring", exc_info=True)
+        return {}
+
+    city_block = payload.get("cities")
+    if not isinstance(city_block, dict):
+        return {}
+
+    normalised: Dict[str, Dict[str, List[str]]] = {}
+    for city in clean_cities:
+        data = city_block.get(city) or city_block.get(city.lower()) or {}
+        if not isinstance(data, dict):
+            data = {}
+        highlights = [item for item in data.get("highlights", []) if isinstance(item, str)]
+        experiences = [item for item in data.get("experiences", []) if isinstance(item, str)]
+        dining = [item for item in data.get("dining", []) if isinstance(item, str)]
+        notes = [item for item in data.get("notes", []) if isinstance(item, str)]
+        normalised[city] = {
+            "highlights": highlights[:4],
+            "experiences": experiences[:5],
+            "dining": dining[:3],
+            "notes": notes[:3],
+        }
+
+    return normalised

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -36,6 +36,20 @@ class Stay(BaseModel):
     style: Literal["hotel", "boutique", "homestay", "apartment"] = "hotel"
     budget_per_night: float
 
+class BookingLink(BaseModel):
+    category: Literal[
+        "stay",
+        "flight",
+        "train",
+        "bus",
+        "local_pass",
+        "sightseeing",
+        "transport",
+    ]
+    label: str
+    url: str
+    details: Optional[str] = None
+
 class TravelLeg(BaseModel):
     mode: Literal["flight","train","bus","car","rideshare","metro","walk","ferry"]
     frm: str = Field(..., alias="from")
@@ -57,6 +71,8 @@ class AgentContext(BaseModel):
     notes: List[str] = Field(default_factory=list)
     sources: List[Dict[str, str]] = Field(default_factory=list)
     snippets: List[Dict[str, str]] = Field(default_factory=list)
+    costs: Dict[str, object] = Field(default_factory=dict)
+    llm_sources: List[Dict[str, object]] = Field(default_factory=list)
 
 class PlanBundle(BaseModel):
     label: Literal["balanced","cheapest","comfort","family_friendly"]
@@ -73,6 +89,7 @@ class PlanBundle(BaseModel):
     feasibility_notes: List[str] = Field(default_factory=list)
     transfer_buffers: Dict[str, float] = Field(default_factory=dict)
     scores: Dict[str, float] = Field(default_factory=dict)
+    booking_links: List[BookingLink] = Field(default_factory=list)
 
 class TripResponse(BaseModel):
     query_echo: TripRequest

--- a/tests/test_orchestrator_scoring.py
+++ b/tests/test_orchestrator_scoring.py
@@ -41,3 +41,13 @@ def test_max_flight_hours_penalises_comfort_plan():
     assert response.options[0].label != "comfort"
     comfort = next(opt for opt in response.options if opt.label == "comfort")
     assert comfort.scores["time"] < 0.8
+
+
+def test_plan_bundles_surface_booking_links():
+    response = plan_trip(_build_request("balanced"))
+    top_option = response.options[0]
+    assert top_option.booking_links, "expected booking links for the top bundle"
+    categories = {link.category for link in top_option.booking_links}
+    assert "stay" in categories
+    assert "local_pass" in categories
+    assert any(cat in categories for cat in {"train", "bus", "flight", "transport"})

--- a/trip_planner_frontend/README.md
+++ b/trip_planner_frontend/README.md
@@ -1,0 +1,53 @@
+# Trip Planner Frontend
+
+A lightweight React + Vite workspace that mirrors conversational trip-planning tools like [Mindtrip](https://mindtrip.ai/chat/) and [Airial](https://www.airial.travel/chat). The UI pairs a chat-inspired request lane with rich itinerary cards, booking links, and source attribution so travellers can move from inspiration to checkout in one place.
+
+## Getting started
+
+```bash
+cd trip_planner_frontend
+npm install
+npm run dev
+```
+
+The development server defaults to `http://localhost:5173`.
+
+### Connecting to the orchestrator API
+
+Set the backend endpoint that exposes `POST /api/plan` using a Vite environment variable:
+
+```bash
+# .env.local
+VITE_API_BASE_URL=http://localhost:8000
+```
+
+When the value is missing or the request fails, the app falls back to an interactive sample itinerary so the interface stays explorable offline.
+
+## Project structure
+
+```
+trip_planner_frontend/
+├── index.html             # Single-page app shell
+├── package.json           # React + Vite dependencies and scripts
+├── src/
+│   ├── App.jsx            # High-level layout and data fetching
+│   ├── components/        # Chat, bundles, booking links, and source widgets
+│   ├── lib/sampleData.js  # Sample TripResponse mirroring the orchestrator schema
+│   └── index.css          # Global typography and resets
+└── vite.config.js         # Vite dev/build configuration
+```
+
+## Design notes
+
+- **Dual-column canvas** – The left column captures the conversation and traveller inputs. The right column visualises the generated trip with booking shortcuts, bundle comparisons, and attribution.
+- **Booking-first UX** – Every bundle exposes structured booking links (stays, rail, flights, passes, experiences) so users can jump straight into checkout flows.
+- **Source transparency** – Web sources and language-model backfills are displayed alongside the itinerary, mirroring the backend contract that tracks citation metadata.
+
+## Production build
+
+```bash
+npm run build
+npm run preview
+```
+
+The Vite build emits static assets in `dist/` which can be hosted on any static file service or wired into your Python application as an embedded frontend.

--- a/trip_planner_frontend/index.html
+++ b/trip_planner_frontend/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Trip Planner Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/trip_planner_frontend/package-lock.json
+++ b/trip_planner_frontend/package-lock.json
@@ -1,0 +1,1614 @@
+{
+  "name": "trip-planner-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "trip-planner-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "^4.2.0",
+        "vite": "^5.2.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.2.tgz",
+      "integrity": "sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.2.tgz",
+      "integrity": "sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.2.tgz",
+      "integrity": "sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.2.tgz",
+      "integrity": "sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.2.tgz",
+      "integrity": "sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.2.tgz",
+      "integrity": "sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.2.tgz",
+      "integrity": "sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.2.tgz",
+      "integrity": "sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.2.tgz",
+      "integrity": "sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.2.tgz",
+      "integrity": "sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.50.2.tgz",
+      "integrity": "sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.2.tgz",
+      "integrity": "sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.2.tgz",
+      "integrity": "sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.2.tgz",
+      "integrity": "sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.2.tgz",
+      "integrity": "sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.2.tgz",
+      "integrity": "sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.2.tgz",
+      "integrity": "sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.2.tgz",
+      "integrity": "sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.2.tgz",
+      "integrity": "sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.2.tgz",
+      "integrity": "sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.2.tgz",
+      "integrity": "sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.4.tgz",
+      "integrity": "sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
+      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.3",
+        "caniuse-lite": "^1.0.30001741",
+        "electron-to-chromium": "^1.5.218",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001743",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.220",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.220.tgz",
+      "integrity": "sha512-TWXijEwR1ggr4BdAKrb1nMNqYLTx1/4aD1fkeZU+FVJGTKu53/T7UyHKXlqEX3Ub02csyHePbHmkvnrjcaYzMA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+      "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.2.tgz",
+      "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.50.2",
+        "@rollup/rollup-android-arm64": "4.50.2",
+        "@rollup/rollup-darwin-arm64": "4.50.2",
+        "@rollup/rollup-darwin-x64": "4.50.2",
+        "@rollup/rollup-freebsd-arm64": "4.50.2",
+        "@rollup/rollup-freebsd-x64": "4.50.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.50.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.50.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.50.2",
+        "@rollup/rollup-linux-arm64-musl": "4.50.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.50.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.50.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.50.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.50.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.50.2",
+        "@rollup/rollup-linux-x64-gnu": "4.50.2",
+        "@rollup/rollup-linux-x64-musl": "4.50.2",
+        "@rollup/rollup-openharmony-arm64": "4.50.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.50.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.50.2",
+        "@rollup/rollup-win32-x64-msvc": "4.50.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/trip_planner_frontend/package.json
+++ b/trip_planner_frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "trip-planner-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/trip_planner_frontend/src/App.css
+++ b/trip_planner_frontend/src/App.css
@@ -1,0 +1,77 @@
+.app-shell {
+  min-height: 100vh;
+  padding: 40px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 1.25fr);
+  gap: 28px;
+}
+
+.app-shell__column {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.app-shell__column--left {
+  position: sticky;
+  top: 40px;
+  align-self: start;
+  height: fit-content;
+}
+
+.app-shell__notes {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 20px;
+  display: grid;
+  gap: 12px;
+}
+
+.app-shell__notes h3 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #475467;
+}
+
+.app-shell__notes ul {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 8px;
+  color: #1f2937;
+}
+
+.app-shell__status {
+  border-radius: 12px;
+  padding: 14px 16px;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.app-shell__status--warning {
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fcd34d;
+}
+
+.app-shell__status--info {
+  background: #e0e7ff;
+  color: #312e81;
+  border: 1px solid #c7d2fe;
+}
+
+@media (max-width: 1100px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+    padding: 24px;
+  }
+
+  .app-shell__column--left {
+    position: static;
+  }
+}

--- a/trip_planner_frontend/src/App.jsx
+++ b/trip_planner_frontend/src/App.jsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import PlanForm from './components/PlanForm.jsx';
+import ChatPanel from './components/ChatPanel.jsx';
+import PlanSummary from './components/PlanSummary.jsx';
+import BundlesView from './components/BundlesView.jsx';
+import SourceList from './components/SourceList.jsx';
+import { sampleRequest, sampleResponse } from './lib/sampleData.js';
+import './App.css';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, '') ?? '';
+
+function buildRequestPayload(formValues) {
+  return {
+    ...sampleRequest,
+    origin: formValues.origin || sampleRequest.origin,
+    destinations: formValues.destinations.length ? formValues.destinations : sampleRequest.destinations,
+    dates: {
+      start: formValues.startDate || sampleRequest.dates.start,
+      end: formValues.endDate || sampleRequest.dates.end,
+    },
+    budget_total: Number.isFinite(formValues.budget) && formValues.budget > 0 ? formValues.budget : sampleRequest.budget_total,
+    party: {
+      adults: formValues.adults ?? sampleRequest.party.adults,
+      children: formValues.children ?? sampleRequest.party.children,
+      seniors: formValues.seniors ?? sampleRequest.party.seniors,
+    },
+    prefs: {
+      ...sampleRequest.prefs,
+      objective: formValues.objective || sampleRequest.prefs.objective,
+    },
+  };
+}
+
+function formatDestinations(destinations) {
+  return destinations.length ? destinations.join(', ') : 'your selected cities';
+}
+
+const initialMessages = [
+  {
+    id: 'intro',
+    role: 'assistant',
+    content:
+      'Share your origin, dream destinations, travel window, and budget. I will research travel legs, propose lodging mixes, and surface ready-to-book links.',
+  },
+];
+
+function App() {
+  const [messages, setMessages] = useState(initialMessages);
+  const [planResult, setPlanResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [usedSampleFallback, setUsedSampleFallback] = useState(false);
+
+  const bundles = planResult?.baseline_plan?.options ?? [];
+  const sources = planResult?.agent_context?.sources ?? [];
+  const llmSources = planResult?.agent_context?.llm_sources ?? [];
+  const planNotes = planResult?.agent_context?.notes ?? [];
+
+  const addMessage = (message) => {
+    setMessages((prev) => [...prev, { ...message, id: `${message.role}-${Date.now()}-${Math.random().toString(16).slice(2)}` }]);
+  };
+
+  const handlePlanSubmit = async (formValues) => {
+    const requestPayload = buildRequestPayload(formValues);
+
+    addMessage({
+      role: 'user',
+      content: `I want to travel from ${requestPayload.origin} to ${formatDestinations(requestPayload.destinations)} between ${requestPayload.dates.start} and ${requestPayload.dates.end} with a budget of $${requestPayload.budget_total}.` ,
+    });
+
+    setLoading(true);
+    setError('');
+    setUsedSampleFallback(false);
+
+    try {
+      if (!API_BASE_URL) {
+        throw new Error('API base URL not configured.');
+      }
+
+      const response = await fetch(`${API_BASE_URL}/api/plan`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestPayload),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Planner API responded with ${response.status}`);
+      }
+
+      const data = await response.json();
+      setPlanResult(data);
+      addMessage({
+        role: 'assistant',
+        content:
+          data.trip_plan?.overview ??
+          'Here is the latest itinerary including bundles, logistics, and booking shortcuts.',
+      });
+    } catch (fetchError) {
+      console.warn('Falling back to sample response', fetchError);
+      setPlanResult(sampleResponse);
+      setError('Planner API unavailable. Showing interactive sample instead.');
+      setUsedSampleFallback(true);
+      addMessage({
+        role: 'assistant',
+        content:
+          'Live scraping is offline, so I loaded a curated sample itinerary. Configure VITE_API_BASE_URL to connect your orchestrator.',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="app-shell">
+      <div className="app-shell__column app-shell__column--left">
+        <ChatPanel messages={messages} />
+        <PlanForm onSubmit={handlePlanSubmit} loading={loading} />
+        {error ? <div className="app-shell__status app-shell__status--warning">{error}</div> : null}
+        {usedSampleFallback ? (
+          <div className="app-shell__status app-shell__status--info">
+            Using offline sample data. Start the orchestrator API and set <code>VITE_API_BASE_URL</code> to see live web-sourced content.
+          </div>
+        ) : null}
+      </div>
+      <div className="app-shell__column app-shell__column--right">
+        <PlanSummary tripPlan={planResult?.trip_plan} />
+        {planNotes.length ? (
+          <section className="app-shell__notes">
+            <h3>Operational notes</h3>
+            <ul>
+              {planNotes.map((note) => (
+                <li key={note}>{note}</li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+        <BundlesView bundles={bundles} />
+        <SourceList sources={sources} llmSources={llmSources} />
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/trip_planner_frontend/src/components/BookingLinks.css
+++ b/trip_planner_frontend/src/components/BookingLinks.css
@@ -1,0 +1,45 @@
+.booking-links {
+  display: grid;
+  gap: 16px;
+}
+
+.booking-links__group {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 16px;
+}
+
+.booking-links__group h4 {
+  margin: 0 0 12px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #1d4ed8;
+}
+
+.booking-links__group ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.booking-links__group li a {
+  color: #1f2937;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.booking-links__group li a:hover {
+  text-decoration: underline;
+}
+
+.booking-links__details {
+  display: block;
+  color: #475467;
+  font-size: 0.85rem;
+  margin-top: 4px;
+}

--- a/trip_planner_frontend/src/components/BookingLinks.jsx
+++ b/trip_planner_frontend/src/components/BookingLinks.jsx
@@ -1,0 +1,50 @@
+import './BookingLinks.css';
+
+const CATEGORY_LABELS = {
+  flight: 'Flights',
+  train: 'Rail',
+  bus: 'Coach',
+  stay: 'Stays',
+  local_pass: 'City passes',
+  sightseeing: 'Experiences',
+  transport: 'Transport',
+};
+
+function groupByCategory(links) {
+  return links.reduce((acc, link) => {
+    const bucket = acc.get(link.category) ?? [];
+    bucket.push(link);
+    acc.set(link.category, bucket);
+    return acc;
+  }, new Map());
+}
+
+function BookingLinks({ links }) {
+  if (!links?.length) {
+    return null;
+  }
+
+  const grouped = groupByCategory(links);
+
+  return (
+    <div className="booking-links">
+      {[...grouped.entries()].map(([category, categoryLinks]) => (
+        <div key={category} className="booking-links__group">
+          <h4>{CATEGORY_LABELS[category] ?? category}</h4>
+          <ul>
+            {categoryLinks.map((link) => (
+              <li key={`${category}-${link.label}`}>
+                <a href={link.url} target="_blank" rel="noreferrer">
+                  {link.label}
+                </a>
+                {link.details ? <span className="booking-links__details">{link.details}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default BookingLinks;

--- a/trip_planner_frontend/src/components/BundleCard.css
+++ b/trip_planner_frontend/src/components/BundleCard.css
@@ -1,0 +1,88 @@
+.bundle-card {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+}
+
+.bundle-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.bundle-card__label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  font-size: 0.75rem;
+  color: #6366f1;
+}
+
+.bundle-card__header h3 {
+  margin: 8px 0 0;
+  font-size: 1.1rem;
+  color: #1f2937;
+}
+
+.bundle-card__price {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.bundle-card__section h4 {
+  margin: 0 0 12px;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #475467;
+}
+
+.bundle-card__section ul {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 8px;
+  color: #1f2937;
+}
+
+.bundle-card__section--grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.bundle-card__experiences {
+  list-style: none;
+  padding: 0;
+}
+
+.bundle-card__experiences li {
+  display: grid;
+  gap: 4px;
+  background: #f8fafc;
+  border-radius: 12px;
+  padding: 12px;
+  border: 1px solid #e2e8f0;
+}
+
+.bundle-card__experiences strong {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: #3b82f6;
+}
+
+.bundle-card__gem {
+  font-size: 0.85rem;
+  color: #0f172a;
+}
+
+.bundle-card__footer ul {
+  list-style: disc;
+  padding-left: 20px;
+}

--- a/trip_planner_frontend/src/components/BundleCard.jsx
+++ b/trip_planner_frontend/src/components/BundleCard.jsx
@@ -1,0 +1,91 @@
+import BookingLinks from './BookingLinks.jsx';
+import './BundleCard.css';
+
+function formatCurrency(value, currency) {
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0,
+    }).format(value);
+  } catch (error) {
+    return `${currency} ${value.toFixed(0)}`;
+  }
+}
+
+function BundleCard({ bundle }) {
+  return (
+    <article className="bundle-card">
+      <header className="bundle-card__header">
+        <div>
+          <span className="bundle-card__label">{bundle.label}</span>
+          <h3>{bundle.summary}</h3>
+        </div>
+        <div className="bundle-card__price">{formatCurrency(bundle.total_cost, bundle.currency)}</div>
+      </header>
+
+      <div className="bundle-card__section">
+        <h4>Travel legs</h4>
+        <ul>
+          {bundle.travel.map((leg, index) => (
+            <li key={`${leg.frm}-${leg.to}-${index}`}>
+              <strong>{leg.mode}</strong> · {leg.frm} → {leg.to}
+              {leg.date ? ` on ${leg.date}` : ''}
+              {leg.duration_hr ? ` · ${leg.duration_hr.toFixed(1)}h` : ''}
+              {typeof leg.cost_estimate === 'number'
+                ? ` · ${formatCurrency(leg.cost_estimate, bundle.currency)}`
+                : ''}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="bundle-card__section bundle-card__section--grid">
+        <div>
+          <h4>Stays</h4>
+          <ul>
+            {bundle.stays.map((stay) => (
+              <li key={`${stay.city}-${stay.style}`}>
+                {stay.city}: {stay.nights} nights · {stay.style}
+                {' · '}
+                {formatCurrency(stay.budget_per_night, bundle.currency)} / night
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h4>Daily highlights</h4>
+          <ul className="bundle-card__experiences">
+            {bundle.experience_plan.map((plan) => (
+              <li key={plan.city}>
+                <strong>{plan.city}</strong>
+                <span>{plan.must_do[0]}</span>
+                {plan.hidden_gem[0] ? <span className="bundle-card__gem">Hidden gem: {plan.hidden_gem[0]}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {bundle.booking_links?.length ? (
+        <div className="bundle-card__section">
+          <h4>Bundle booking links</h4>
+          <BookingLinks links={bundle.booking_links} />
+        </div>
+      ) : null}
+
+      {bundle.notes?.length ? (
+        <div className="bundle-card__footer">
+          <h4>Notes</h4>
+          <ul>
+            {bundle.notes.map((note) => (
+              <li key={note}>{note}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+export default BundleCard;

--- a/trip_planner_frontend/src/components/BundlesView.css
+++ b/trip_planner_frontend/src/components/BundlesView.css
@@ -1,0 +1,13 @@
+.bundles-view {
+  display: grid;
+  gap: 24px;
+}
+
+.bundles-view--empty {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 36px;
+  text-align: center;
+  color: #475467;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.1);
+}

--- a/trip_planner_frontend/src/components/BundlesView.jsx
+++ b/trip_planner_frontend/src/components/BundlesView.jsx
@@ -1,0 +1,22 @@
+import BundleCard from './BundleCard.jsx';
+import './BundlesView.css';
+
+function BundlesView({ bundles }) {
+  if (!bundles?.length) {
+    return (
+      <section className="bundles-view bundles-view--empty">
+        <p>Your tailored itineraries will appear here once a plan has been generated.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="bundles-view">
+      {bundles.map((bundle) => (
+        <BundleCard key={bundle.label} bundle={bundle} />
+      ))}
+    </section>
+  );
+}
+
+export default BundlesView;

--- a/trip_planner_frontend/src/components/ChatPanel.css
+++ b/trip_planner_frontend/src/components/ChatPanel.css
@@ -1,0 +1,90 @@
+.chat-panel {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+  height: 100%;
+}
+
+.chat-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.chat-panel__header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.chat-panel__header p {
+  margin: 4px 0 0;
+  color: #475467;
+}
+
+.chat-panel__badge {
+  background: rgba(99, 102, 241, 0.12);
+  color: #4338ca;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.chat-panel__conversation {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-height: 480px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.chat-bubble {
+  padding: 16px;
+  border-radius: 18px;
+  max-width: 90%;
+  line-height: 1.6;
+  font-size: 0.95rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.chat-bubble--user {
+  margin-left: auto;
+  background: linear-gradient(135deg, #6366f1, #a855f7);
+  color: #ffffff;
+}
+
+.chat-bubble--assistant {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+
+.chat-bubble__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: inherit;
+  opacity: 0.75;
+}
+
+.chat-bubble__role {
+  font-weight: 600;
+}
+
+.chat-bubble__time {
+  font-feature-settings: 'tnum';
+}
+
+.chat-bubble p {
+  margin: 0;
+  white-space: pre-wrap;
+}

--- a/trip_planner_frontend/src/components/ChatPanel.jsx
+++ b/trip_planner_frontend/src/components/ChatPanel.jsx
@@ -1,0 +1,35 @@
+import './ChatPanel.css';
+
+function ChatBubble({ role, content, timestamp }) {
+  const isUser = role === 'user';
+  return (
+    <div className={`chat-bubble ${isUser ? 'chat-bubble--user' : 'chat-bubble--assistant'}`}>
+      <div className="chat-bubble__meta">
+        <span className="chat-bubble__role">{isUser ? 'You' : 'Trip Studio'}</span>
+        {timestamp ? <span className="chat-bubble__time">{timestamp}</span> : null}
+      </div>
+      <p>{content}</p>
+    </div>
+  );
+}
+
+function ChatPanel({ messages }) {
+  return (
+    <section className="chat-panel">
+      <header className="chat-panel__header">
+        <div>
+          <h1>Trip planning workspace</h1>
+          <p>Inspired by conversational planners like Mindtrip and Airial.</p>
+        </div>
+        <span className="chat-panel__badge">Preview</span>
+      </header>
+      <div className="chat-panel__conversation">
+        {messages.map((message) => (
+          <ChatBubble key={message.id} {...message} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default ChatPanel;

--- a/trip_planner_frontend/src/components/PlanForm.css
+++ b/trip_planner_frontend/src/components/PlanForm.css
@@ -1,0 +1,78 @@
+.plan-form {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+}
+
+.plan-form__header h2 {
+  margin: 0 0 4px;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.plan-form__header p {
+  margin: 0;
+  color: #475467;
+  font-size: 0.95rem;
+}
+
+.plan-form__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.plan-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: #475467;
+}
+
+.plan-form__field span {
+  font-weight: 500;
+}
+
+.plan-form__field input,
+.plan-form__field select {
+  border: 1px solid #d0d5dd;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 0.95rem;
+  transition: border 0.2s ease;
+}
+
+.plan-form__field input:focus,
+.plan-form__field select:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.plan-form__submit {
+  align-self: flex-start;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #ffffff;
+  border: none;
+  padding: 12px 20px;
+  font-size: 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.plan-form__submit:disabled {
+  background: #c7d2fe;
+  cursor: wait;
+  box-shadow: none;
+}
+
+.plan-form__submit:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(99, 102, 241, 0.3);
+}

--- a/trip_planner_frontend/src/components/PlanForm.jsx
+++ b/trip_planner_frontend/src/components/PlanForm.jsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import './PlanForm.css';
+
+const defaultState = {
+  origin: 'San Francisco',
+  destinations: 'Paris, Amsterdam, Berlin',
+  startDate: '2025-10-10',
+  endDate: '2025-10-20',
+  budget: '4500',
+  adults: '2',
+  children: '1',
+  seniors: '0',
+  objective: 'balanced',
+};
+
+function PlanForm({ onSubmit, loading }) {
+  const [form, setForm] = useState(defaultState);
+
+  const updateField = (key) => (event) => {
+    setForm((prev) => ({ ...prev, [key]: event.target.value }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (!onSubmit) {
+      return;
+    }
+
+    const destinations = form.destinations
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+
+    onSubmit({
+      origin: form.origin.trim(),
+      destinations,
+      startDate: form.startDate,
+      endDate: form.endDate,
+      budget: Number.parseFloat(form.budget || '0'),
+      adults: Number.parseInt(form.adults || '0', 10),
+      children: Number.parseInt(form.children || '0', 10),
+      seniors: Number.parseInt(form.seniors || '0', 10),
+      objective: form.objective,
+    });
+  };
+
+  return (
+    <form className="plan-form" onSubmit={handleSubmit}>
+      <div className="plan-form__header">
+        <h2>Design a trip</h2>
+        <p>Describe the travellers, target cities, dates, and overall budget.</p>
+      </div>
+
+      <div className="plan-form__grid">
+        <label className="plan-form__field">
+          <span>Origin</span>
+          <input value={form.origin} onChange={updateField('origin')} placeholder="Home airport" />
+        </label>
+
+        <label className="plan-form__field">
+          <span>Destinations</span>
+          <input
+            value={form.destinations}
+            onChange={updateField('destinations')}
+            placeholder="Comma-separated"
+          />
+        </label>
+
+        <label className="plan-form__field">
+          <span>Start date</span>
+          <input type="date" value={form.startDate} onChange={updateField('startDate')} />
+        </label>
+
+        <label className="plan-form__field">
+          <span>End date</span>
+          <input type="date" value={form.endDate} onChange={updateField('endDate')} />
+        </label>
+
+        <label className="plan-form__field">
+          <span>Budget (total)</span>
+          <input type="number" min="0" value={form.budget} onChange={updateField('budget')} />
+        </label>
+
+        <label className="plan-form__field">
+          <span>Objective</span>
+          <select value={form.objective} onChange={updateField('objective')}>
+            <option value="balanced">Balanced</option>
+            <option value="cheapest">Cheapest</option>
+            <option value="comfort">Comfort</option>
+            <option value="family_friendly">Family friendly</option>
+          </select>
+        </label>
+
+        <label className="plan-form__field">
+          <span>Adults</span>
+          <input type="number" min="0" value={form.adults} onChange={updateField('adults')} />
+        </label>
+
+        <label className="plan-form__field">
+          <span>Children</span>
+          <input type="number" min="0" value={form.children} onChange={updateField('children')} />
+        </label>
+
+        <label className="plan-form__field">
+          <span>Seniors</span>
+          <input type="number" min="0" value={form.seniors} onChange={updateField('seniors')} />
+        </label>
+      </div>
+
+      <button type="submit" className="plan-form__submit" disabled={loading}>
+        {loading ? 'Generating...' : 'Generate plan'}
+      </button>
+    </form>
+  );
+}
+
+export default PlanForm;

--- a/trip_planner_frontend/src/components/PlanSummary.css
+++ b/trip_planner_frontend/src/components/PlanSummary.css
@@ -1,0 +1,48 @@
+.plan-summary {
+  background: linear-gradient(180deg, #ffffff 0%, #f9fafc 100%);
+  border-radius: 20px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5), 0 15px 35px rgba(15, 23, 42, 0.1);
+}
+
+.plan-summary header h2 {
+  margin: 0 0 8px;
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.plan-summary header p {
+  margin: 0;
+  color: #475467;
+  font-size: 1rem;
+}
+
+.plan-summary__bullets {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 8px;
+  color: #1f2937;
+}
+
+.plan-summary__links h3 {
+  margin: 0 0 12px;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.plan-summary--empty {
+  align-items: center;
+  text-align: center;
+  color: #475467;
+  min-height: 200px;
+  justify-content: center;
+}
+
+.plan-summary--empty h3 {
+  margin-bottom: 8px;
+  color: #1f2937;
+}

--- a/trip_planner_frontend/src/components/PlanSummary.jsx
+++ b/trip_planner_frontend/src/components/PlanSummary.jsx
@@ -1,0 +1,37 @@
+import BookingLinks from './BookingLinks.jsx';
+import './PlanSummary.css';
+
+function PlanSummary({ tripPlan }) {
+  if (!tripPlan) {
+    return (
+      <section className="plan-summary plan-summary--empty">
+        <h3>Ready when you are</h3>
+        <p>Generate a plan to unlock booking links, timelines, and curated experiences.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="plan-summary">
+      <header>
+        <h2>{tripPlan.title}</h2>
+        <p>{tripPlan.overview}</p>
+      </header>
+
+      {tripPlan.summary_points?.length ? (
+        <ul className="plan-summary__bullets">
+          {tripPlan.summary_points.map((point) => (
+            <li key={point}>{point}</li>
+          ))}
+        </ul>
+      ) : null}
+
+      <div className="plan-summary__links">
+        <h3>Booking shortcuts</h3>
+        <BookingLinks links={tripPlan.booking_links} />
+      </div>
+    </section>
+  );
+}
+
+export default PlanSummary;

--- a/trip_planner_frontend/src/components/SourceList.css
+++ b/trip_planner_frontend/src/components/SourceList.css
@@ -1,0 +1,52 @@
+.source-list {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 24px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.source-list h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.source-list__grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.source-list__grid article {
+  background: #f8fafc;
+  border-radius: 14px;
+  padding: 14px;
+  border: 1px solid #e2e8f0;
+  display: grid;
+  gap: 8px;
+}
+
+.source-list__grid h4 {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #475467;
+}
+
+.source-list__grid a {
+  color: #1d4ed8;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.source-list__grid a:hover {
+  text-decoration: underline;
+}
+
+.source-list__llm {
+  background: #eef2ff;
+  border-color: #c7d2fe;
+}

--- a/trip_planner_frontend/src/components/SourceList.jsx
+++ b/trip_planner_frontend/src/components/SourceList.jsx
@@ -1,0 +1,34 @@
+import './SourceList.css';
+
+function SourceList({ sources = [], llmSources = [] }) {
+  if (!sources.length && !llmSources.length) {
+    return null;
+  }
+
+  return (
+    <section className="source-list">
+      <h3>Sources</h3>
+      <div className="source-list__grid">
+        {sources.map((source) => (
+          <article key={`${source.city}-${source.url}`}>
+            <h4>{source.city}</h4>
+            <a href={source.url} target="_blank" rel="noreferrer">
+              {source.title}
+            </a>
+          </article>
+        ))}
+        {llmSources.map((entry) => (
+          <article key={`llm-${entry.model}`} className="source-list__llm">
+            <h4>Model</h4>
+            <p>
+              <strong>{entry.model}</strong>
+            </p>
+            {entry.reason ? <p>{entry.reason}</p> : null}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default SourceList;

--- a/trip_planner_frontend/src/index.css
+++ b/trip_planner_frontend/src/index.css
@@ -1,0 +1,24 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #101828;
+  background-color: #f5f5f7;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font-family: inherit;
+}

--- a/trip_planner_frontend/src/lib/sampleData.js
+++ b/trip_planner_frontend/src/lib/sampleData.js
@@ -1,0 +1,364 @@
+export const sampleRequest = {
+  origin: 'San Francisco',
+  destinations: ['Paris', 'Amsterdam', 'Berlin'],
+  dates: {
+    start: '2025-10-10',
+    end: '2025-10-20',
+  },
+  budget_total: 4500,
+  currency: 'USD',
+  party: {
+    adults: 2,
+    children: 1,
+    seniors: 0,
+  },
+  prefs: {
+    objective: 'balanced',
+    flexible_days: 0,
+    max_flight_hours: 12,
+    diet: ['vegetarian'],
+    mobility: 'normal',
+  },
+};
+
+export const sampleResponse = {
+  trip_plan: {
+    title: 'Autumn escape: Paris, Amsterdam & Berlin',
+    overview:
+      'Ten autumn nights weaving Parisian art, Dutch canals, and Berlin history with vegetarian-friendly picks for the whole family.',
+    summary_points: [
+      'Fly into Paris for four nights, then hop north by high-speed rail.',
+      'Blend headline museums with family-flexible afternoons and market time.',
+      'Wrap in Berlin with hands-on history walks and bikeable neighborhoods.',
+    ],
+    booking_links: [
+      {
+        category: 'flight',
+        label: 'SFO → CDG nonstop (Air France)',
+        url: 'https://www.airfrance.us/',
+        details: 'Sample fare for 10 Oct 2025 departure, return 20 Oct 2025.',
+      },
+      {
+        category: 'train',
+        label: 'Paris → Amsterdam (Eurostar, 14 Oct)',
+        url: 'https://www.eurostar.com/us-en',
+        details: 'Select 09:25 departure to arrive by lunch at Amsterdam Centraal.',
+      },
+      {
+        category: 'train',
+        label: 'Amsterdam → Berlin (ICE, 17 Oct)',
+        url: 'https://www.bahn.com/en/offers/regional/ic',
+        details: 'Direct ICE 1592 typically from €39 per adult when booked early.',
+      },
+      {
+        category: 'stay',
+        label: 'Hoxton Paris family loft',
+        url: 'https://thehoxton.com/paris/rooms/',
+        details: 'Fits 2 adults + 1 child with breakfast add-on.',
+      },
+      {
+        category: 'local_pass',
+        label: 'Paris Museum Pass (4 days)',
+        url: 'https://www.parismuseumpass.fr/t-en',
+      },
+      {
+        category: 'sightseeing',
+        label: 'Berlin Story Bunker timed ticket',
+        url: 'https://www.getyourguide.com/berlin-story-museum-l4305/',
+      },
+    ],
+  },
+  baseline_plan: {
+    query_echo: sampleRequest,
+    options: [
+      {
+        label: 'balanced',
+        summary:
+          'High-speed trains between cities, boutique hotels near major sights, and prebooked passes keep the pace steady.',
+        total_cost: 3985.4,
+        currency: 'USD',
+        transfers: 2,
+        est_duration_days: 11,
+        travel: [
+          {
+            mode: 'train',
+            frm: 'Paris',
+            to: 'Amsterdam',
+            date: '2025-10-14',
+            duration_hr: 3.25,
+            cost_estimate: 115,
+          },
+          {
+            mode: 'train',
+            frm: 'Amsterdam',
+            to: 'Berlin',
+            date: '2025-10-17',
+            duration_hr: 6.25,
+            cost_estimate: 95,
+          },
+        ],
+        stays: [
+          { city: 'Paris', nights: 4, style: 'boutique', budget_per_night: 260 },
+          { city: 'Amsterdam', nights: 3, style: 'boutique', budget_per_night: 245 },
+          { city: 'Berlin', nights: 3, style: 'boutique', budget_per_night: 210 },
+        ],
+        local_transport: ['Navigo Easy', 'GVB day cards', 'Berlin WelcomeCard'],
+        experience_plan: [
+          {
+            city: 'Paris',
+            must_do: [
+              'Timed Louvre entry + family highlights tour',
+              'Evening Seine cruise with vegetarian dinner buffet',
+            ],
+            hidden_gem: ['Atelier des Lumières immersive light show'],
+            flex_hours: 3,
+          },
+          {
+            city: 'Amsterdam',
+            must_do: ['Van Gogh Museum family guide', 'Private canal cruise at sunset'],
+            hidden_gem: ['Jordaan food crawl focused on veggie bites'],
+            flex_hours: 2,
+          },
+          {
+            city: 'Berlin',
+            must_do: ['Berlin Wall Memorial storyteller tour', 'Museum of Technology hands-on labs'],
+            hidden_gem: ['Tempelhofer Feld picnic and kite session'],
+            flex_hours: 2,
+          },
+        ],
+        notes: [
+          'Reserve key museum slots 60+ days ahead to secure family entry windows.',
+          'Keep one evening free in each city for spontaneous finds or rest.',
+        ],
+        feasibility_notes: [
+          'Rail timings assume morning departures with one-hour buffers at stations.',
+          'All totals include vegetarian-friendly dining estimates at $160/day for the family.',
+        ],
+        transfer_buffers: {
+          'Paris->Amsterdam': 1,
+          'Amsterdam->Berlin': 1.5,
+        },
+        scores: {
+          cost: 0.78,
+          time: 0.82,
+          experience: 0.9,
+          composite: 0.84,
+        },
+        booking_links: [
+          {
+            category: 'train',
+            label: 'Paris → Amsterdam Eurostar seats',
+            url: 'https://www.eurostar.com/us-en/train/france/paris/paris-to-amsterdam',
+          },
+          {
+            category: 'stay',
+            label: 'Pulitzer Amsterdam connecting rooms',
+            url: 'https://www.pulitzeramsterdam.com/rooms-suites/',
+          },
+          {
+            category: 'sightseeing',
+            label: 'Anne Frank House family entry',
+            url: 'https://www.annefrank.org/en/museum/tickets/',
+          },
+        ],
+      },
+      {
+        label: 'cheapest',
+        summary: 'Self-catering apartments and slower regional trains stretch the budget.',
+        total_cost: 3150,
+        currency: 'USD',
+        transfers: 2,
+        est_duration_days: 11,
+        travel: [
+          {
+            mode: 'train',
+            frm: 'Paris',
+            to: 'Amsterdam',
+            date: '2025-10-14',
+            duration_hr: 3.75,
+            cost_estimate: 75,
+          },
+          {
+            mode: 'train',
+            frm: 'Amsterdam',
+            to: 'Berlin',
+            date: '2025-10-17',
+            duration_hr: 6.5,
+            cost_estimate: 69,
+          },
+        ],
+        stays: [
+          { city: 'Paris', nights: 4, style: 'apartment', budget_per_night: 180 },
+          { city: 'Amsterdam', nights: 3, style: 'homestay', budget_per_night: 165 },
+          { city: 'Berlin', nights: 3, style: 'apartment', budget_per_night: 150 },
+        ],
+        local_transport: ['Carnet metro tickets', 'OV-chipkaart', 'Berlin ABC transit pass'],
+        experience_plan: [
+          {
+            city: 'Paris',
+            must_do: ['Free walking tour of Île de la Cité', 'Picnic at Luxembourg Gardens'],
+            hidden_gem: ['Canal Saint-Martin family paddle boats'],
+            flex_hours: 4,
+          },
+          {
+            city: 'Amsterdam',
+            must_do: ['Cycling tour using MacBike rentals', 'Science day at NEMO museum'],
+            hidden_gem: ['Tony\'s Chocolonely superstore tasting flight'],
+            flex_hours: 3,
+          },
+          {
+            city: 'Berlin',
+            must_do: ['Free city walking tour from Brandenburg Gate', 'Exploratorium creative lab'],
+            hidden_gem: ['Thaiwiese Sunday food market'],
+            flex_hours: 3,
+          },
+        ],
+        notes: [
+          'Swap some restaurant meals for market picnics to stay on target.',
+          'Regional train fares assume advance purchase saver tickets.',
+        ],
+        feasibility_notes: ['Apartments sourced within 15 minutes of central transit hubs.'],
+        transfer_buffers: {
+          'Paris->Amsterdam': 0.75,
+          'Amsterdam->Berlin': 1,
+        },
+        scores: {
+          cost: 0.92,
+          time: 0.6,
+          experience: 0.74,
+          composite: 0.76,
+        },
+        booking_links: [
+          {
+            category: 'stay',
+            label: 'Paris Citadines République apartment',
+            url: 'https://www.discoverasr.com/en/citadines/france/citadines-republique-paris',
+          },
+          {
+            category: 'local_pass',
+            label: 'Amsterdam Go City pass (2-day)',
+            url: 'https://gocity.com/amsterdam/en-us/products/explorer',
+          },
+          {
+            category: 'bus',
+            label: 'FlixBus fallback Amsterdam ↔ Berlin',
+            url: 'https://www.flixbus.com/bus/amsterdam/berlin',
+          },
+        ],
+      },
+      {
+        label: 'comfort',
+        summary: 'Business-class flights, five-star suites, and private guides across all three cities.',
+        total_cost: 6125,
+        currency: 'USD',
+        transfers: 2,
+        est_duration_days: 11,
+        travel: [
+          {
+            mode: 'flight',
+            frm: 'Paris',
+            to: 'Amsterdam',
+            date: '2025-10-14',
+            duration_hr: 1.1,
+            cost_estimate: 240,
+          },
+          {
+            mode: 'flight',
+            frm: 'Amsterdam',
+            to: 'Berlin',
+            date: '2025-10-17',
+            duration_hr: 1.3,
+            cost_estimate: 260,
+          },
+        ],
+        stays: [
+          { city: 'Paris', nights: 4, style: 'boutique', budget_per_night: 420 },
+          { city: 'Amsterdam', nights: 3, style: 'boutique', budget_per_night: 410 },
+          { city: 'Berlin', nights: 3, style: 'boutique', budget_per_night: 360 },
+        ],
+        local_transport: ['Private car service', 'Canal boat with skipper', 'Private driver'],
+        experience_plan: [
+          {
+            city: 'Paris',
+            must_do: ['Private Louvre before-hours tour', 'Chef-led cooking class with market visit'],
+            hidden_gem: ['Champagne day trip with driver'],
+            flex_hours: 2,
+          },
+          {
+            city: 'Amsterdam',
+            must_do: ['Exclusive Rijksmuseum after-hours tour', 'Windmill countryside helicopter hop'],
+            hidden_gem: ['Micropia scientist meet-and-greet'],
+            flex_hours: 2,
+          },
+          {
+            city: 'Berlin',
+            must_do: ['Private Third Reich history guide', 'Street art workshop in Friedrichshain'],
+            hidden_gem: ['Chef\'s table at Cookies Cream vegetarian fine dining'],
+            flex_hours: 1,
+          },
+        ],
+        notes: ['Daily spa access and childcare add-ons baked into totals.'],
+        feasibility_notes: [
+          'Premium flight fares from SkyTeam carriers with through-check baggage.',
+          'Private guides sourced through Virtuoso partners with family credentials.',
+        ],
+        transfer_buffers: {
+          'Paris->Amsterdam': 2,
+          'Amsterdam->Berlin': 2,
+        },
+        scores: {
+          cost: 0.52,
+          time: 0.95,
+          experience: 0.98,
+          composite: 0.86,
+        },
+        booking_links: [
+          {
+            category: 'flight',
+            label: 'Air France Business Flex SFO ↔ CDG',
+            url: 'https://www.airfrance.us/plan-your-trip/book-a-flight',
+          },
+          {
+            category: 'stay',
+            label: 'Waldorf Astoria Amsterdam two-bedroom suite',
+            url: 'https://www.hilton.com/en/hotels/amstwwa-waldorf-astoria-amsterdam/rooms/',
+          },
+          {
+            category: 'sightseeing',
+            label: 'Berlin private guide collective',
+            url: 'https://www.toursbylocals.com/Berlin-Tours',
+          },
+        ],
+      },
+    ],
+  },
+  agent_context: {
+    notes: [
+      'Live pricing to be refreshed within 24h of booking to capture fare shifts.',
+      'LLM (gpt-4o-mini) supplied supplemental descriptions where live snippets were unavailable.',
+    ],
+    sources: [
+      {
+        city: 'Paris',
+        title: 'Paris Museum Pass official site',
+        url: 'https://www.parismuseumpass.fr/t-en',
+      },
+      {
+        city: 'Amsterdam',
+        title: 'GVB public transport day tickets',
+        url: 'https://www.gvb.nl/en/tickets',
+      },
+      {
+        city: 'Berlin',
+        title: 'Deutsche Bahn saver fares overview',
+        url: 'https://www.bahn.com/en/offers/long-distance/saver-fares-europe',
+      },
+    ],
+    llm_sources: [
+      {
+        model: 'gpt-4o-mini',
+        reason: 'Filled in attraction blurbs when scraping fell back to heuristics.',
+      },
+    ],
+  },
+};

--- a/trip_planner_frontend/src/main.jsx
+++ b/trip_planner_frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/trip_planner_frontend/vite.config.js
+++ b/trip_planner_frontend/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig(() => ({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: true,
+  },
+  preview: {
+    port: 5173,
+  },
+}));


### PR DESCRIPTION
## Summary
- add a React + Vite workspace that mirrors the orchestrator contract with chat-style inputs and bundle visualisations
- surface booking links, per-bundle itineraries, and citation metadata including LLM fallbacks
- document the new frontend entry point and ignore Node build outputs

## Testing
- uv run pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca51ce207483319527eb2cde80e944