### PR TITLE
Expose planner endpoint at /api/plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Launch the API server with uvicorn:
 uv run uvicorn app.main:app --reload
 ```
 
-The primary endpoint is `POST /plan`, which accepts the `TripRequest` schema
+The primary endpoint is `POST /api/plan`, which accepts the `TripRequest` schema
 from `app/schemas.py`. Example payload:
 
 ```json

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,9 @@ from app.orchestrator import orchestrate_llm_trip
 from fastapi import Body
 app = FastAPI(title="Trip Planner Agentic API")
 
-@app.post("/trip/llm_only")
+
+@app.post("/api/plan")
+@app.post("/trip/llm_only", include_in_schema=False)
 async def trip_llm_only(
     origin: str = Body(...),
     purpose: str = Body(...),


### PR DESCRIPTION
## Summary
- expose the orchestrator at `/api/plan` and keep the legacy `/trip/llm_only` route as an undocumented alias
- update the README so the documented endpoint matches the API implementation

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca7733a1a08331aee62b7766de37be