### PR TITLE
Collect trip purpose in planner UI

### DIFF
--- a/trip_planner_frontend/src/App.jsx
+++ b/trip_planner_frontend/src/App.jsx
@@ -18,6 +18,7 @@ function buildRequestPayload(formValues) {
       start: formValues.startDate || sampleRequest.dates.start,
       end: formValues.endDate || sampleRequest.dates.end,
     },
+    purpose: formValues.purpose || sampleRequest.purpose,
     budget_total: Number.isFinite(formValues.budget) && formValues.budget > 0 ? formValues.budget : sampleRequest.budget_total,
     party: {
       adults: formValues.adults ?? sampleRequest.party.adults,

--- a/trip_planner_frontend/src/components/PlanForm.jsx
+++ b/trip_planner_frontend/src/components/PlanForm.jsx
@@ -6,6 +6,7 @@ const defaultState = {
   destinations: 'Paris, Amsterdam, Berlin',
   startDate: '2025-10-10',
   endDate: '2025-10-20',
+  purpose: 'Family vacation',
   budget: '4500',
   adults: '2',
   children: '1',
@@ -36,6 +37,7 @@ function PlanForm({ onSubmit, loading }) {
       destinations,
       startDate: form.startDate,
       endDate: form.endDate,
+      purpose: form.purpose.trim(),
       budget: Number.parseFloat(form.budget || '0'),
       adults: Number.parseInt(form.adults || '0', 10),
       children: Number.parseInt(form.children || '0', 10),
@@ -79,6 +81,15 @@ function PlanForm({ onSubmit, loading }) {
         <label className="plan-form__field">
           <span>Budget (total)</span>
           <input type="number" min="0" value={form.budget} onChange={updateField('budget')} />
+        </label>
+
+        <label className="plan-form__field">
+          <span>Purpose</span>
+          <input
+            value={form.purpose}
+            onChange={updateField('purpose')}
+            placeholder="Family vacation, business retreat, etc."
+          />
         </label>
 
         <label className="plan-form__field">

--- a/trip_planner_frontend/src/lib/sampleData.js
+++ b/trip_planner_frontend/src/lib/sampleData.js
@@ -5,6 +5,7 @@ export const sampleRequest = {
     start: '2025-10-10',
     end: '2025-10-20',
   },
+  purpose: 'family vacation',
   budget_total: 4500,
   currency: 'USD',
   party: {


### PR DESCRIPTION
## Summary
- add a purpose input to the planner form so requests include the trip goal
- extend the request payload builder and sample data to forward the purpose string to the API

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca781a07b483319979331ea0c2d283