### PR TITLE
Add frontend-backend integration test and fix orchestrator context

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -463,11 +463,12 @@ async def orchestrate_llm_trip(
         logger.info("WebSearcher unavailable; continuing with heuristic planning only")
 
     # Derive richer context from specialised agents.
-destination_context = expand_destinations(foundation, snippets)
+    destination_context = expand_destinations(foundation, snippets)
+    logistics_context = compute_logistics(foundation)
 
-llm_sources: List[Dict[str, Any]] = []
-heuristic_cities: List[str] = destination_context.get("heuristic_cities", []) or []
-remaining_heuristics = set(heuristic_cities)
+    llm_sources: List[Dict[str, Any]] = []
+    heuristic_cities: List[str] = destination_context.get("heuristic_cities", []) or []
+    remaining_heuristics = set(heuristic_cities)
     if heuristic_cities:
         missing_details: List[str] = []
         for city in heuristic_cities:

--- a/tests/test_frontend_backend_integration.py
+++ b/tests/test_frontend_backend_integration.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _build_frontend_payload(form_values: dict) -> dict:
+    if shutil.which("node") is None:
+        pytest.skip("Node.js is required to execute the frontend payload builder")
+
+    script = f"""
+import {{ buildRequestPayload }} from './trip_planner_frontend/src/lib/payload.js';
+const formValues = {json.dumps(form_values)};
+const payload = buildRequestPayload(formValues);
+console.log(JSON.stringify(payload));
+"""
+
+    result = subprocess.run(  # noqa: S603
+        ["node", "--input-type=module", "-e", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_frontend_payload_passes_through_api(monkeypatch):
+    payload = _build_frontend_payload(
+        {
+            "origin": "Los Angeles",
+            "destinations": ["Kyoto", "Tokyo"],
+            "startDate": "2026-03-01",
+            "endDate": "2026-03-11",
+            "budget": 6800,
+            "adults": 2,
+            "children": 2,
+            "seniors": 1,
+            "objective": "family_friendly",
+        }
+    )
+
+    orchestrator = AsyncMock(return_value={"status": "ok", "bundle_count": 2})
+    monkeypatch.setattr("app.main.orchestrate_llm_trip", orchestrator)
+
+    client = TestClient(app)
+    response = client.post("/api/plan", json=payload)
+
+    assert response.status_code == 200
+    orchestrator.assert_awaited_once()
+
+    called_payload = orchestrator.await_args.args[0]
+    assert called_payload["origin"] == "Los Angeles"
+    assert called_payload["dates"]["start"] == "2026-03-01"
+    assert called_payload["dates"]["end"] == "2026-03-11"
+    assert called_payload["purpose"] == "family vacation"
+    assert called_payload["party"]["seniors"] == 1
+    assert called_payload["prefs"]["objective"] == "family_friendly"
+
+    assert response.json() == {"status": "ok", "bundle_count": 2}

--- a/trip_planner_frontend/src/App.jsx
+++ b/trip_planner_frontend/src/App.jsx
@@ -4,46 +4,11 @@ import ChatPanel from './components/ChatPanel.jsx';
 import PlanSummary from './components/PlanSummary.jsx';
 import BundlesView from './components/BundlesView.jsx';
 import SourceList from './components/SourceList.jsx';
-import { sampleRequest, sampleResponse } from './lib/sampleData.js';
+import { sampleResponse } from './lib/sampleData.js';
+import { buildRequestPayload } from './lib/payload.js';
 import './App.css';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, '') ?? '';
-
-function inferPurpose(objective) {
-  switch (objective) {
-    case 'family_friendly':
-      return 'family vacation';
-    case 'comfort':
-      return 'premium leisure escape';
-    case 'cheapest':
-      return 'budget getaway';
-    default:
-      return 'leisure';
-  }
-}
-
-function buildRequestPayload(formValues) {
-  return {
-    ...sampleRequest,
-    origin: formValues.origin || sampleRequest.origin,
-    destinations: formValues.destinations.length ? formValues.destinations : sampleRequest.destinations,
-    dates: {
-      start: formValues.startDate || sampleRequest.dates.start,
-      end: formValues.endDate || sampleRequest.dates.end,
-    },
-    budget_total: Number.isFinite(formValues.budget) && formValues.budget > 0 ? formValues.budget : sampleRequest.budget_total,
-    party: {
-      adults: formValues.adults ?? sampleRequest.party.adults,
-      children: formValues.children ?? sampleRequest.party.children,
-      seniors: formValues.seniors ?? sampleRequest.party.seniors,
-    },
-    purpose: formValues.purpose?.trim() || inferPurpose(formValues.objective),
-    prefs: {
-      ...sampleRequest.prefs,
-      objective: formValues.objective || sampleRequest.prefs.objective,
-    },
-  };
-}
 
 function formatDestinations(destinations) {
   return destinations.length ? destinations.join(', ') : 'your selected cities';

--- a/trip_planner_frontend/src/lib/payload.js
+++ b/trip_planner_frontend/src/lib/payload.js
@@ -1,0 +1,44 @@
+import { sampleRequest } from './sampleData.js';
+
+export function inferPurpose(objective) {
+  switch (objective) {
+    case 'family_friendly':
+      return 'family vacation';
+    case 'comfort':
+      return 'premium leisure escape';
+    case 'cheapest':
+      return 'budget getaway';
+    default:
+      return 'leisure';
+  }
+}
+
+export function buildRequestPayload(formValues = {}) {
+  const destinations = Array.isArray(formValues.destinations)
+    ? formValues.destinations.filter(Boolean)
+    : [];
+
+  return {
+    ...sampleRequest,
+    origin: formValues.origin || sampleRequest.origin,
+    destinations: destinations.length ? destinations : sampleRequest.destinations,
+    dates: {
+      start: formValues.startDate || sampleRequest.dates.start,
+      end: formValues.endDate || sampleRequest.dates.end,
+    },
+    budget_total:
+      Number.isFinite(formValues.budget) && formValues.budget > 0
+        ? formValues.budget
+        : sampleRequest.budget_total,
+    party: {
+      adults: formValues.adults ?? sampleRequest.party.adults,
+      children: formValues.children ?? sampleRequest.party.children,
+      seniors: formValues.seniors ?? sampleRequest.party.seniors,
+    },
+    purpose: formValues.purpose?.trim() || inferPurpose(formValues.objective),
+    prefs: {
+      ...sampleRequest.prefs,
+      objective: formValues.objective || sampleRequest.prefs.objective,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- extract the frontend request payload builder into a dedicated module that can be reused outside the React component
- add a pytest that invokes the frontend payload builder via Node.js and exercises the FastAPI endpoint end-to-end with a stubbed orchestrator
- fix the orchestrator to compute logistics context and clean up indentation so downstream aggregation logic works during the test

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68cac0faa88883318923331e91bb40a5