### PR TITLE
Allow runtime API keys from UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ API (via FastAPI) or exercised locally to inspect orchestration logs.
 - [uv](https://github.com/astral-sh/uv) (recommended) or `pip` for dependency
   management.
 - An OpenAI API key stored in `OPENAI_API_KEY` if you want to call the hosted
-  model. Without it, the system falls back to deterministic stub responses.
-- A Tavily API key (`TAVILY_API_KEY`) for live web search. When absent the
-  orchestrator retains heuristic city highlights and logs the fallback path.
+  model. You can also provide a per-request key from the React UI without
+  storing it server-side. Without it, the system falls back to deterministic
+  stub responses.
+- A Tavily API key (`TAVILY_API_KEY`) for live web search. This may also be
+  supplied at request time via the UI so each traveller can bring their own
+  credentials. When absent the orchestrator retains heuristic city highlights
+  and logs the fallback path.
 - Optional: credentials for your preferred web-search adapter. The default
   implementation does not require authentication, but you can plug in your own
   tool by editing `app/tools/websearch.py`.
@@ -69,6 +73,45 @@ budget at a glance.
 If you need to restrict browser origins, configure
 `TRIP_PLANNER_ALLOWED_ORIGINS` (comma-separated list). The default `*` keeps
 local development simple by allowing the Vite dev server to call the API.
+
+## Sharing with friends
+
+To let friends try the orchestrator with their own API credentials, deploy both
+the FastAPI backend and the static frontend and point them at the same base URL.
+
+1. **Deploy the backend** – Package the FastAPI service behind Uvicorn or
+   Gunicorn and expose it publicly. A typical command for platforms such as
+   Render, Railway, or Fly.io is:
+
+   ```bash
+   uv run uvicorn app.main:app --host 0.0.0.0 --port 8000
+   ```
+
+   Configure `TRIP_PLANNER_ALLOWED_ORIGINS` with the URL of your hosted UI to
+   prevent cross-origin rejections.
+
+2. **Build and host the frontend** – Generate the static bundle and publish the
+   contents of `trip_planner_frontend/dist` to your preferred host (Vercel,
+   Netlify, GitHub Pages, or an S3 bucket behind a CDN work well):
+
+   ```bash
+   cd trip_planner_frontend
+   npm install
+   npm run build
+   ```
+
+   Set `VITE_API_BASE_URL` to the public backend URL before building so the SPA
+   posts to the correct host.
+
+3. **Communicate the security model** – The React form now includes optional
+   password inputs for the OpenAI and Tavily API keys. Keys are forwarded to the
+   backend for a single request and never logged or echoed in responses. Advise
+   friends to use HTTPS (e.g., via your platform’s TLS support) before sharing
+   their credentials.
+
+Alternatively, share the repository so friends can run both backend and
+frontend locally with their own `.env` files. The UI defaults to localhost and
+works offline with a bundled sample itinerary when the backend is unavailable.
 
 ## Inspecting orchestration logs
 

--- a/tests/test_frontend_backend_integration.py
+++ b/tests/test_frontend_backend_integration.py
@@ -59,12 +59,50 @@ def test_frontend_payload_passes_through_api(monkeypatch):
     assert response.status_code == 200
     orchestrator.assert_awaited_once()
 
-    called_payload = orchestrator.await_args.args[0]
+    called_args = orchestrator.await_args.args
+    called_kwargs = orchestrator.await_args.kwargs
+    called_payload = called_args[0]
     assert called_payload["origin"] == "Los Angeles"
     assert called_payload["dates"]["start"] == "2026-03-01"
     assert called_payload["dates"]["end"] == "2026-03-11"
     assert called_payload["purpose"] == "family vacation"
     assert called_payload["party"]["seniors"] == 1
     assert called_payload["prefs"]["objective"] == "family_friendly"
+    assert called_kwargs.get("openai_api_key") is None
+    assert called_kwargs.get("tavily_api_key") is None
 
     assert response.json() == {"status": "ok", "bundle_count": 2}
+
+
+def test_frontend_payload_forwards_api_keys(monkeypatch):
+    payload = _build_frontend_payload(
+        {
+            "origin": "Chicago",
+            "destinations": ["Lisbon"],
+            "startDate": "2026-05-10",
+            "endDate": "2026-05-20",
+            "budget": 5200,
+            "adults": 2,
+            "children": 0,
+            "seniors": 0,
+            "objective": "comfort",
+            "openAiKey": "sk-override",
+            "tavilyKey": "tv-override",
+        }
+    )
+
+    assert payload["openai_api_key"] == "sk-override"
+    assert payload["tavily_api_key"] == "tv-override"
+
+    orchestrator = AsyncMock(return_value={"status": "ok", "bundle_count": 1})
+    monkeypatch.setattr("app.main.orchestrate_llm_trip", orchestrator)
+
+    client = TestClient(app)
+    response = client.post("/api/plan", json=payload)
+
+    assert response.status_code == 200
+    orchestrator.assert_awaited_once()
+
+    called_kwargs = orchestrator.await_args.kwargs
+    assert called_kwargs["openai_api_key"] == "sk-override"
+    assert called_kwargs["tavily_api_key"] == "tv-override"

--- a/tests/test_websearch.py
+++ b/tests/test_websearch.py
@@ -98,7 +98,7 @@ def test_orchestrator_dedupes_and_fetches_unique_results(monkeypatch):
 
         collected_snippets = {}
 
-        def fake_call_llm(payload, snippets):
+        def fake_call_llm(payload, snippets, **kwargs):
             collected_snippets["value"] = list(snippets)
             return {"llm": "ok"}
 
@@ -107,8 +107,9 @@ def test_orchestrator_dedupes_and_fetches_unique_results(monkeypatch):
         instances = []
 
         class FakeSearcher:
-            def __init__(self, policy):
+            def __init__(self, policy, api_key=None):
                 self.policy = policy
+                self.api_key = api_key
                 self.search_calls: List[str] = []
                 self.fetch_calls: List[str] = []
                 instances.append(self)
@@ -169,7 +170,7 @@ def test_orchestrator_uses_search_summaries_when_fetch_fails(monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         from app import orchestrator
 
-        def fake_call_llm(payload, snippets):
+        def fake_call_llm(payload, snippets, **kwargs):
             # Return predictable payload while capturing snippets for inspection.
             run.captured = list(snippets)
             return {"llm": "ok"}
@@ -177,8 +178,9 @@ def test_orchestrator_uses_search_summaries_when_fetch_fails(monkeypatch):
         monkeypatch.setattr(orchestrator, "call_llm", fake_call_llm)
 
         class FakeSearcher:
-            def __init__(self, policy):
+            def __init__(self, policy, api_key=None):
                 self.policy = policy
+                self.api_key = api_key
                 self.fetch_calls: List[str] = []
 
             async def search(self, query: str):
@@ -231,7 +233,7 @@ def test_orchestrator_respects_payload_domain_lists(monkeypatch):
 
         captured_snippets: Dict[str, List[Dict[str, str]]] = {}
 
-        def fake_call_llm(payload, snippets):
+        def fake_call_llm(payload, snippets, **kwargs):
             captured_snippets["value"] = list(snippets)
             return {"llm": "ok"}
 
@@ -240,8 +242,9 @@ def test_orchestrator_respects_payload_domain_lists(monkeypatch):
         instances: List[object] = []
 
         class FakeSearcher:
-            def __init__(self, policy):
+            def __init__(self, policy, api_key=None):
                 self.policy = policy
+                self.api_key = api_key
                 self.search_calls: List[str] = []
                 self.fetch_calls: List[str] = []
                 instances.append(self)
@@ -305,7 +308,7 @@ def test_orchestrator_foundation_preserves_user_extras(monkeypatch):
 
         captured: Dict[str, Any] = {}
 
-        def fake_call_llm(payload, snippets):
+        def fake_call_llm(payload, snippets, **kwargs):
             captured["agent_context"] = payload.get("agent_context")
             return {"llm": "ok"}
 
@@ -346,7 +349,7 @@ def test_orchestrator_llm_backfill_updates_destination(monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         from app import orchestrator
 
-        def fake_call_llm(payload, snippets):
+        def fake_call_llm(payload, snippets, **kwargs):
             return {"llm": "ok"}
 
         monkeypatch.setattr(orchestrator, "call_llm", fake_call_llm)
@@ -354,7 +357,7 @@ def test_orchestrator_llm_backfill_updates_destination(monkeypatch):
 
         captured_cities: Dict[str, Any] = {}
 
-        def fake_llm_backfill(cities, foundation, model="gpt-4o-mini"):
+        def fake_llm_backfill(cities, foundation, model="gpt-4o-mini", **kwargs):
             captured_cities["value"] = {"cities": list(cities), "model": model}
             return {
                 "Paris": {

--- a/trip_planner_frontend/README.md
+++ b/trip_planner_frontend/README.md
@@ -23,6 +23,13 @@ VITE_API_BASE_URL=http://localhost:8000
 
 When the value is missing or the request fails, the app falls back to an interactive sample itinerary so the interface stays explorable offline.
 
+### Runtime API keys
+
+The Plan form exposes optional password inputs for OpenAI and Tavily API keys.
+Keys are forwarded with a single request and are never stored by the frontend.
+This allows each traveller to bring their own credentials when you host the UI
+for friends or colleagues.
+
 ## Project structure
 
 ```

--- a/trip_planner_frontend/src/components/PlanForm.css
+++ b/trip_planner_frontend/src/components/PlanForm.css
@@ -26,6 +26,10 @@
   gap: 16px;
 }
 
+.plan-form__grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
 .plan-form__field {
   display: flex;
   flex-direction: column;
@@ -45,6 +49,29 @@
   padding: 10px 12px;
   font-size: 0.95rem;
   transition: border 0.2s ease;
+}
+
+.plan-form__section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid #e4e7ec;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.plan-form__section-header h3 {
+  margin: 0 0 4px;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.plan-form__section-header p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #475467;
 }
 
 .plan-form__field input:focus,

--- a/trip_planner_frontend/src/components/PlanForm.jsx
+++ b/trip_planner_frontend/src/components/PlanForm.jsx
@@ -11,6 +11,8 @@ const defaultState = {
   children: '1',
   seniors: '0',
   objective: 'balanced',
+  openAiKey: '',
+  tavilyKey: '',
 };
 
 function PlanForm({ onSubmit, loading }) {
@@ -41,6 +43,8 @@ function PlanForm({ onSubmit, loading }) {
       children: Number.parseInt(form.children || '0', 10),
       seniors: Number.parseInt(form.seniors || '0', 10),
       objective: form.objective,
+      openAiKey: form.openAiKey.trim(),
+      tavilyKey: form.tavilyKey.trim(),
     });
   };
 
@@ -105,6 +109,37 @@ function PlanForm({ onSubmit, loading }) {
           <span>Seniors</span>
           <input type="number" min="0" value={form.seniors} onChange={updateField('seniors')} />
         </label>
+      </div>
+
+      <div className="plan-form__section">
+        <div className="plan-form__section-header">
+          <h3>Bring your own API access (optional)</h3>
+          <p>Keys are forwarded with this request only and are not stored by the UI.</p>
+        </div>
+
+        <div className="plan-form__grid plan-form__grid--compact">
+          <label className="plan-form__field">
+            <span>OpenAI API key</span>
+            <input
+              type="password"
+              value={form.openAiKey}
+              onChange={updateField('openAiKey')}
+              placeholder="sk-..."
+              autoComplete="off"
+            />
+          </label>
+
+          <label className="plan-form__field">
+            <span>Tavily API key</span>
+            <input
+              type="password"
+              value={form.tavilyKey}
+              onChange={updateField('tavilyKey')}
+              placeholder="tvly-..."
+              autoComplete="off"
+            />
+          </label>
+        </div>
       </div>
 
       <button type="submit" className="plan-form__submit" disabled={loading}>

--- a/trip_planner_frontend/src/lib/payload.js
+++ b/trip_planner_frontend/src/lib/payload.js
@@ -40,5 +40,21 @@ export function buildRequestPayload(formValues = {}) {
       ...sampleRequest.prefs,
       objective: formValues.objective || sampleRequest.prefs.objective,
     },
+    ...pickApiKeys(formValues),
   };
+}
+
+function pickApiKeys(formValues) {
+  const payload = {};
+  const openAiKey = typeof formValues.openAiKey === 'string' ? formValues.openAiKey.trim() : '';
+  const tavilyKey = typeof formValues.tavilyKey === 'string' ? formValues.tavilyKey.trim() : '';
+
+  if (openAiKey) {
+    payload.openai_api_key = openAiKey;
+  }
+  if (tavilyKey) {
+    payload.tavily_api_key = tavilyKey;
+  }
+
+  return payload;
 }


### PR DESCRIPTION
## Summary
- add optional OpenAI and Tavily credential inputs to the trip request form and include them in the payload builder
- plumb caller-supplied API keys through FastAPI, the orchestrator, and the OpenAI client to use one-off credentials per request
- update tests and docs to cover the new key handling workflow and deployment guidance for sharing the app

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbad10bc6c833197dcfd4d85a97dd2